### PR TITLE
Fix accessing out of scope variable

### DIFF
--- a/pe_trimmer.py
+++ b/pe_trimmer.py
@@ -196,6 +196,7 @@ class PETrimmer:
             logging.debug("Max iterations to take: %d", max_steps)
             logging.info("Beginning to remove bytes...")
 
+            i = 0
             for i in range(1, max_steps):
                 self.trim_pe_data()
 


### PR DESCRIPTION
Fixes the error message "UnboundLocalError: cannot access local variable 'i' where it is not associated with a value", due to line 212.